### PR TITLE
Changes org admin functionality so that org admins can no longer view…

### DIFF
--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,7 +1,7 @@
 class Admin::DashboardController < Admin::BaseController
   
   def index
-    @fundings = Funding.all
+    @fundings = Funding.all 
     @status = @fundings.pluck(:status).uniq
   end
 

--- a/app/controllers/admin/organization/users_controller.rb
+++ b/app/controllers/admin/organization/users_controller.rb
@@ -9,5 +9,4 @@ class Admin::Organization::UsersController < ApplicationController
     @organization = Organization.find_by(slug: params[:organization_slug])
     @user = @organization.users.new
   end
-
 end

--- a/app/controllers/admin/organization/users_controller.rb
+++ b/app/controllers/admin/organization/users_controller.rb
@@ -1,8 +1,8 @@
 class Admin::Organization::UsersController < ApplicationController
 
   def index
-    @organization = Organization.find_by(slug: params[:organization_slug])
-    @admins = @organization.users
+      @organization = Organization.find_by(slug: params[:organization_slug])
+      @admins = @organization.users
   end
 
   def new

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,7 +9,8 @@ class ApplicationController < ActionController::Base
                 :current_user,
                 :current_platform_admin?,
                 :find_recipient,
-                :non_admin?
+                :non_admin?,
+                :current_org_admin?
 
   def authorize!
     unless authorize?
@@ -35,9 +36,9 @@ class ApplicationController < ActionController::Base
   end
 
   def current_platform_admin?
-    current_user && current_user.roles.include?("platform_admin")
-  end
-
+    current_user && current_user.roles.exists?(name: "platform_admin")
+  end  
+  
   def find_recipient(name)
     Recipient.find_by(name: name)
   end
@@ -49,4 +50,8 @@ class ApplicationController < ActionController::Base
   def countries
     Country.all
   end
+  
+  def current_org_admin?(params)
+    current_user.organization.slug == params if current_user.organization
+  end   
 end

--- a/app/controllers/organizations/dashboard_controller.rb
+++ b/app/controllers/organizations/dashboard_controller.rb
@@ -1,5 +1,10 @@
 class Organizations::DashboardController < ApplicationController
   def index
-    @organization = Organization.find_by(slug: params[:organization_slug])
+    if current_org_admin?(params[:organization_slug])
+      @organization = current_user.organization
+    else
+      response.status = 403
+      render file: "/public/403"
+    end
   end
 end

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -16,7 +16,8 @@ class OrganizationsController < ApplicationController
   def create
     @organization = Organization.new(organization_params)
     if @organization.save
-      redirect_to "/#{@organization.slug}/dashboard"
+      current_user.update_attributes(organization_id: @organization.id)
+      redirect_to "/dashboard"
       flash[:success] = "You have submitted your organization application. We'll be in touch once we review it."
     else
       flash[:failure] = "Invalid Information"

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -13,5 +13,5 @@ module ApplicationHelper
 
   def registered_user?
     current_user && current_user.registered_user?
-  end
+  end 
 end

--- a/app/services/permission_service.rb
+++ b/app/services/permission_service.rb
@@ -7,7 +7,7 @@ attr_reader :user
 
   def allow?(controller, action)
     return platform_admin_permissions(controller, action) if user.platform_admin?
-    return org_admin_permissions(controller, action) if user.org_admin?
+    return org_admin_permissions(controller, action) if user.org_admin? 
     return registered_user_permissions(controller, action) if user.registered_user?
     return guest_permissions(controller, action)
   end
@@ -33,7 +33,7 @@ attr_reader :user
       return true if controller == "fundings"
       return true if controller == "carts"
       return true if controller == "organizations/recipients"
-      return true if controller == "organizations/dashboard"
+      return true if controller == "organizations/dashboard" 
       return true if controller == "country/recipients"
       return true if controller == "admin/recipients"
       return true if controller == "users"

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -2,4 +2,8 @@
 
   <%= render partial: "shared/user_profile" %>
 
-  <p><br>Welcome <%= current_user.username %>!
+  <h3>Welcome <%= current_user.username %>!</h3>
+    
+    <% if current_user.organization %>
+      <h3> <%= current_user.organization.name %> Status: <%= current_user.organization.status.capitalize %> </h3>
+    <% end %>

--- a/spec/features/org_admin_cannot_see_other_admin_dashboard_spec.rb
+++ b/spec/features/org_admin_cannot_see_other_admin_dashboard_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.feature "Organization admin sees organization dashboard" do
+  scenario "organization admin cannot see other organizations dashboard" do
+    org_role = Role.create(name: 'org_admin')
+    org = Organization.create!(name:"Homes for Humanity", description: "We build homes", status: 1)
+    other_org = Organization.create!(name:"Cardboard Boxes for Homes", description: "We give out recycling", status: 1)
+    org_user = org.users.create(username: 'fiona@cat.com', password: 'password')
+    org_user.roles << org_role
+
+    visit login_path
+    fill_in 'Username', with: 'fiona@cat.com'
+    fill_in 'Password', with: 'password'
+    click_button 'Login'
+
+    click_link "My Organization"
+    
+    expect(page).to have_content("Homes for Humanity")
+    expect(page).to_not have_content("Cardboard Boxes for Homes")
+    
+    visit '/cardboard-boxes-for-homes/dashboard'
+    expect(page.status_code).to eq(403)
+  end
+end

--- a/spec/features/registered_user_can_create_an_organization_spec.rb
+++ b/spec/features/registered_user_can_create_an_organization_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature "Registered user can create an organization" do
     fill_in "Description", with: 'We protect cats and their humans.'
     click_button ("Submit Organization Application")
 
-    expect(current_path).to eq("/save-the-cats/dashboard")
+    expect(current_path).to eq("/dashboard")
     expect(page).to have_content("Status: Pending")
     expect(page).to_not have_content("Manage Team")
   end


### PR DESCRIPTION
… any other org admin dashboards:

-checks for current user's organization against the organization slug
-renders 403 for current user without an organization
-changes org dashboard#index to check current_org_admin method
-changes the reg user submits organization to redirect to user show page instead of the pending org dashboard index page
-method for checking the current_org_admin lives in the application controller so that org dashboard controller has access to current user